### PR TITLE
publically-viewable token

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -3,8 +3,8 @@
 [color]
     ui = auto
 [github]
-    user = matthewrankin
-    token = 318a9333affe87faeeda4685e0649730
+    user = !cat ~/.github_user
+    token = !cat ~/.github_token
 [alias]
     st = status
     ci = commit


### PR DESCRIPTION
Matthew--

As far as I know, the github token lets anyone be "you" for scripts that don't use SSH (eg. the gist gem). You can use the ! trick to cat it in from files that are not under vc.

-RMc.
